### PR TITLE
Refactor Dashboard component layout and semantics

### DIFF
--- a/app/javascript/src/components/Dashboard/index.jsx
+++ b/app/javascript/src/components/Dashboard/index.jsx
@@ -3,20 +3,22 @@ import React from "react";
 import { Route, Switch } from "react-router-dom";
 
 import PageNotFound from "components/commons/PageNotFound";
-import Sidebar from "components/Dashboard/Sidebar";
 import { DASHBOARD_ROUTES } from "components/routeConstants";
 
+import Sidebar from "./Sidebar";
+
 const Dashboard = () => (
-  <div className="flex">
+  <div className="flex h-screen w-full overflow-hidden">
     <Sidebar />
-    <div className="w-full">
+    <main className="flex-grow overflow-y-auto">
       <Switch>
         {DASHBOARD_ROUTES.map(({ path, component }) => (
           <Route exact component={component} key={path} path={path} />
         ))}
         <Route component={PageNotFound} path="*" />
       </Switch>
-    </div>
+    </main>
   </div>
 );
+
 export default Dashboard;


### PR DESCRIPTION
This PR refactors the `Dashboard/index.jsx` component to:
- Use a more semantic `<main>` tag for the content area.
- Add `h-screen` and `overflow-hidden` to the dashboard container to ensure it fits the viewport.
- Set `flex-grow` and `overflow-y-auto` to the content area to handle internal scrolling independently of the sidebar.
- Use a relative import for the `Sidebar` component.
- Improve overall structure and accessibility.