### PR TITLE
Refactor Dashboard index layout

### DIFF
--- a/app/javascript/src/components/Dashboard/index.jsx
+++ b/app/javascript/src/components/Dashboard/index.jsx
@@ -7,16 +7,17 @@ import Sidebar from "components/Dashboard/Sidebar";
 import { DASHBOARD_ROUTES } from "components/routeConstants";
 
 const Dashboard = () => (
-  <div className="flex">
+  <div className="flex h-screen w-full overflow-hidden">
     <Sidebar />
-    <div className="w-full">
+    <div className="flex-1 overflow-y-auto">
       <Switch>
-        {DASHBOARD_ROUTES.map(({ path, component }) => (
-          <Route exact component={component} key={path} path={path} />
+        {DASHBOARD_ROUTES.map(({ path, component: Component }) => (
+          <Route exact component={Component} key={path} path={path} />
         ))}
         <Route component={PageNotFound} path="*" />
       </Switch>
     </div>
   </div>
 );
+
 export default Dashboard;


### PR DESCRIPTION
The following changes were made to `app/javascript/src/components/Dashboard/index.jsx`:
- Added `h-screen`, `w-full`, and `overflow-hidden` to the main container to ensure the dashboard fills the viewport correctly and the sidebar stays fixed.
- Replaced `w-full` with `flex-1` on the main content area to properly handle the space next to the sidebar in the flex container.
- Added `overflow-y-auto` to the content area to allow independent scrolling.
- Refactored the route mapping to use a capitalized `Component` for better readability and adherence to React conventions.
