### PR TITLE
Refactor ChatsController for safety and readability

### DIFF
--- a/app/controllers/api/v1/chats_controller.rb
+++ b/app/controllers/api/v1/chats_controller.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 class Api::V1::ChatsController < Api::V1::BaseController
-  before_action :load_chat!, only: :show
+  before_action :load_chat!, only: %i[show question]
 
   def index
-    @chats = current_user.chats.all.order(created_at: :desc)
+    @chats = current_user.chats.order(created_at: :desc)
   end
 
   def show
@@ -12,7 +12,7 @@ class Api::V1::ChatsController < Api::V1::BaseController
   end
 
   def question
-    answer = QuestionAnswerService.new(question_answer_params[:question], params[:id]).process
+    answer = QuestionAnswerService.new(question_params[:question], @chat.id).process
     render_json({ answer: })
   end
 
@@ -24,7 +24,7 @@ class Api::V1::ChatsController < Api::V1::BaseController
       render_error(t("chat.invalid"))
     end
 
-    def question_answer_params
+    def question_params
       params.require(:chats).permit(:question)
     end
 end


### PR DESCRIPTION
Refactored `Api::V1::ChatsController` for better safety and readability.

### Changes:
- **Security**: Applied `load_chat!` to the `question` action. This ensures that the chat being questioned belongs to the `current_user`. Previously, the `QuestionAnswerService` would find any chat by ID without verifying ownership in the controller.
- **Cleanup**: Removed redundant `.all` call in the `index` action.
- **Naming**: Renamed `question_answer_params` to `question_params`.
- **Consistency**: Used the loaded `@chat.id` instead of `params[:id]` in the `question` action.